### PR TITLE
PCP-7384: fix: only power on machines with a confirmed off power state

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -73,6 +73,20 @@ var (
 	)
 )
 
+// MAAS power_state values, mirroring the MAAS POWER_STATE enum.
+//
+// Only MachinePowerStateOn and MachinePowerStateOff are positive confirmations that MAAS
+// successfully queried the BMC. MachinePowerStateError and MachinePowerStateUnknown (as well
+// as an empty or any unrecognised value) mean the query itself did not yield a chassis state -
+// the host is very often still running, with only its management path unreachable. Never treat
+// those as a confirmed off.
+const (
+	MachinePowerStateOn      = "on"
+	MachinePowerStateOff     = "off"
+	MachinePowerStateError   = "error"
+	MachinePowerStateUnknown = "unknown"
+)
+
 // Instance describes an MAAS Machine.
 type Machine struct {
 	ID string
@@ -85,6 +99,11 @@ type Machine struct {
 
 	// The current state of the machine.
 	Powered bool
+
+	// PowerState is the raw MAAS power_state reading: "on", "off", "error", or "" (unknown).
+	// Kept alongside Powered so callers can distinguish a positively-confirmed off from a
+	// failed BMC query, which Powered alone collapses into false.
+	PowerState string
 
 	// The AZ of the machine
 	AvailabilityZone string

--- a/controllers/maasmachine_controller.go
+++ b/controllers/maasmachine_controller.go
@@ -523,7 +523,7 @@ func (r *MaasMachineReconciler) reconcileNormal(ctx context.Context, machineScop
 		conditions.MarkFalse(machineScope.MaasMachine, infrav1beta1.MachineDeployedCondition, infrav1beta1.MachineTerminatedReason, clusterv1.ConditionSeverityError, "")
 		machineScope.SetFailureReason(capierrors.UpdateMachineError)
 		machineScope.SetFailureMessage(errors.Errorf("Maas machine state %q is unexpected", m.State))
-	case machineScope.MachineIsInKnownState() && !m.Powered:
+	case machineScope.MachineIsInKnownState() && isConfirmedPoweredOff(m.PowerState):
 		if *machineScope.GetMachineState() == infrav1beta1.MachineStateDeployed {
 			machineScope.Info("Deployed machine is powered off trying power on")
 			if err := machineSvc.PowerOnMachine(); err != nil {
@@ -585,6 +585,23 @@ func (r *MaasMachineReconciler) reconcileNormal(ctx context.Context, machineScop
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// isConfirmedPoweredOff reports whether a raw MAAS power_state reading is a positively-confirmed
+// off, and therefore safe to act on by issuing a power-on.
+//
+// MAAS reports "error" (or an empty/unrecognised value) when the BMC query itself failed, which
+// says nothing about the chassis - the host is very often still running, with only its management
+// path unreachable. MAAS's IPMI driver executes op-power_on as `ipmipower --cycle --on-if-off`
+// (Canonical Launchpad #1730089, Won't-Fix), so acting on an unconfirmed reading hard power-cycles
+// a healthy node.
+//
+// Restricting to a confirmed off loses no recovery: MAAS must be able to reach the BMC in order to
+// execute a power-on at all, and whenever it can reach the BMC it reports "on" or "off" - never
+// "error". A genuinely down node therefore reports a confirmed off as soon as its BMC is reachable,
+// and is recovered on that reconcile.
+func isConfirmedPoweredOff(powerState string) bool {
+	return powerState == infrav1beta1.MachinePowerStateOff
 }
 
 func (r *MaasMachineReconciler) deployMachine(machineScope *scope.MachineScope, machineSvc *maasmachine.Service) (*infrav1beta1.Machine, error) {

--- a/controllers/maasmachine_controller.go
+++ b/controllers/maasmachine_controller.go
@@ -540,6 +540,12 @@ func (r *MaasMachineReconciler) reconcileNormal(ctx context.Context, machineScop
 		machineScope.SetNotReady()
 		conditions.MarkFalse(machineScope.MaasMachine, infrav1beta1.MachineDeployedCondition, infrav1beta1.MachineDeployingReason, clusterv1.ConditionSeverityWarning, "")
 	case s == infrav1beta1.MachineStateDeployed:
+		if !m.Powered {
+			// PCP-7384: power state is not a confirmed "off" (error/unknown/"") — the BMC query
+			// failed, so the node is very likely still running. Power-on is intentionally skipped;
+			// log it so the decision is visible instead of silently marking Ready.
+			machineScope.V(1).Info("power state not confirmed off; skipping power-on", "powerState", m.PowerState)
+		}
 		machineScope.SetReady()
 		conditions.MarkTrue(machineScope.MaasMachine, infrav1beta1.MachineDeployedCondition)
 	default:

--- a/controllers/maasmachine_controller_power_test.go
+++ b/controllers/maasmachine_controller_power_test.go
@@ -1,0 +1,58 @@
+package controllers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	infrav1beta1 "github.com/spectrocloud/cluster-api-provider-maas/api/v1beta1"
+)
+
+// TestIsConfirmedPoweredOff is the regression gate for PCP-7384. Only a positively-confirmed
+// "off" may authorise a power-on: MAAS translates op-power_on into `ipmipower --cycle --on-if-off`
+// (Launchpad #1730089), so acting on an unconfirmed reading hard power-cycles a running host.
+func TestIsConfirmedPoweredOff(t *testing.T) {
+	tests := []struct {
+		name          string
+		powerState    string
+		expectPowerOn bool
+	}{
+		{
+			name:          "confirmed off authorises power-on",
+			powerState:    infrav1beta1.MachinePowerStateOff,
+			expectPowerOn: true,
+		},
+		{
+			name:          "confirmed on does not authorise power-on",
+			powerState:    infrav1beta1.MachinePowerStateOn,
+			expectPowerOn: false,
+		},
+		{
+			name:          "failed BMC query must never authorise power-on",
+			powerState:    infrav1beta1.MachinePowerStateError,
+			expectPowerOn: false,
+		},
+		{
+			name:          "unknown must never authorise power-on",
+			powerState:    infrav1beta1.MachinePowerStateUnknown,
+			expectPowerOn: false,
+		},
+		{
+			name:          "empty reading must never authorise power-on",
+			powerState:    "",
+			expectPowerOn: false,
+		},
+		{
+			name:          "unrecognised value must never authorise power-on",
+			powerState:    "Off",
+			expectPowerOn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			g.Expect(isConfirmedPoweredOff(tt.powerState)).To(Equal(tt.expectPowerOn))
+		})
+	}
+}

--- a/pkg/maas/machine/machine.go
+++ b/pkg/maas/machine/machine.go
@@ -1141,11 +1141,13 @@ func fromSDKTypeToMachine(m maasclient.Machine) *infrav1beta1.Machine {
 	if zone != nil && !hasNilValue(zone) {
 		az = zone.Name()
 	}
+	ps := m.PowerState()
 	machine := &infrav1beta1.Machine{
 		ID:               m.SystemID(),
 		Hostname:         m.Hostname(),
 		State:            infrav1beta1.MachineState(m.State()),
-		Powered:          m.PowerState() == "on",
+		Powered:          ps == infrav1beta1.MachinePowerStateOn,
+		PowerState:       ps,
 		AvailabilityZone: az,
 	}
 

--- a/pkg/maas/machine/powerstate_test.go
+++ b/pkg/maas/machine/powerstate_test.go
@@ -1,0 +1,80 @@
+package machine
+
+import (
+	"net"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+
+	infrav1beta1 "github.com/spectrocloud/cluster-api-provider-maas/api/v1beta1"
+	mockclientset "github.com/spectrocloud/cluster-api-provider-maas/pkg/maas/client/mock"
+)
+
+// TestFromSDKTypeToMachinePowerState pins the SDK-boundary contract for PCP-7384: the raw MAAS
+// power_state reading must survive conversion, so the reconciler can tell a positively-confirmed
+// off from a failed BMC query. Powered keeps its original "on"-only semantics - existing consumers
+// (Status.MachinePowered, IsRunning, control-plane DNS) must be unaffected by this change.
+func TestFromSDKTypeToMachinePowerState(t *testing.T) {
+	tests := []struct {
+		name             string
+		powerState       string
+		expectPowered    bool
+		expectPowerState string
+	}{
+		{
+			name:             "confirmed on",
+			powerState:       infrav1beta1.MachinePowerStateOn,
+			expectPowered:    true,
+			expectPowerState: infrav1beta1.MachinePowerStateOn,
+		},
+		{
+			name:             "confirmed off",
+			powerState:       infrav1beta1.MachinePowerStateOff,
+			expectPowered:    false,
+			expectPowerState: infrav1beta1.MachinePowerStateOff,
+		},
+		{
+			name:             "failed BMC query surfaces as error, not off",
+			powerState:       infrav1beta1.MachinePowerStateError,
+			expectPowered:    false,
+			expectPowerState: infrav1beta1.MachinePowerStateError,
+		},
+		{
+			name:             "unknown power state is preserved verbatim",
+			powerState:       infrav1beta1.MachinePowerStateUnknown,
+			expectPowered:    false,
+			expectPowerState: infrav1beta1.MachinePowerStateUnknown,
+		},
+		{
+			name:             "empty power state is preserved verbatim",
+			powerState:       "",
+			expectPowered:    false,
+			expectPowerState: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ctrl := gomock.NewController(t)
+			mockMachine := mockclientset.NewMockMachine(ctrl)
+			mockZone := mockclientset.NewMockZone(ctrl)
+
+			mockMachine.EXPECT().SystemID().Return("abc123")
+			mockMachine.EXPECT().Hostname().Return("abc.hostname")
+			mockMachine.EXPECT().State().Return("Deployed")
+			mockMachine.EXPECT().PowerState().Return(tt.powerState)
+			mockMachine.EXPECT().Zone().Return(mockZone)
+			mockZone.EXPECT().Name().Return("zone1")
+			mockMachine.EXPECT().FQDN().AnyTimes().Return("")
+			mockMachine.EXPECT().IPAddresses().Return([]net.IP{})
+
+			machine := fromSDKTypeToMachine(mockMachine)
+
+			g.Expect(machine.Powered).To(Equal(tt.expectPowered))
+			g.Expect(machine.PowerState).To(Equal(tt.expectPowerState))
+			g.Expect(machine.State).To(BeEquivalentTo("Deployed"))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The MaasMachine reconciler issued `op-power_on` against a `Deployed` machine whenever its power state read as anything other than `"on"` — including `"error"`, `"unknown"` and empty, which MAAS returns when the BMC query itself fails.

MAAS's IPMI driver executes `op-power_on` as `ipmipower --cycle --on-if-off` ([Launchpad #1730089](https://bugs.launchpad.net/maas/+bug/1730089), Won't-Fix), so on a host that is actually running this is a hard power-cycle. A transient BMC-unreachable event therefore rebooted healthy nodes.

## Fix

- Preserve the raw MAAS `power_state` on the internal `Machine` type instead of collapsing it into a single bool.
- Gate the power-on on a positively-confirmed `"off"` (`isConfirmedPoweredOff`).

Safe by construction: MAAS must reach the BMC to execute a power-on at all, and whenever it can it reports `on` or `off`, never `error`. A genuinely down node still reports a confirmed `off` once its BMC is reachable and is recovered on that reconcile.

## No behaviour change elsewhere

`Powered` keeps its existing `== "on"` semantics, so `Status.MachinePowered`, `IsRunning()`, control-plane DNS and the CP counting logic are untouched. `PowerOnMachine()` has a single call site. `Deploying` + confirmed `off` is unchanged. No CRD or API change.

## Tests

- `TestIsConfirmedPoweredOff` — `off` authorises a power-on; `on`/`error`/`unknown`/empty/unrecognised do not.
- `TestFromSDKTypeToMachinePowerState` — raw `power_state` survives conversion; `Powered` semantics unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)