### PR TITLE
Backport/spectro release 4.9/pr 377

### DIFF
--- a/controllers/lxd_initializer_ds_test.go
+++ b/controllers/lxd_initializer_ds_test.go
@@ -1,0 +1,41 @@
+package controllers
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestEnsureLXDScript guards the host LXD bootstrap against the PCP-7159 regressions:
+// probing `command -v lxd` (fooled by the Ubuntu 24.04 lxd-installer stub) and pinning
+// an architecture-specific snap revision.
+func TestEnsureLXDScript(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	raw, err := os.ReadFile("templates/lxd_initializer_ds.yaml")
+	g.Expect(err).ToNot(HaveOccurred())
+	script := string(raw)
+
+	tests := []struct {
+		name     string
+		fragment string
+		want     bool
+	}{
+		{name: "probes the snap binary", fragment: "bash -lc 'test -x /snap/bin/lxd'", want: true},
+		{name: "installs from the verified channel", fragment: "--channel=\"${LXD_CHANNEL}\"", want: true},
+		{name: "channel is the MAAS-verified series", fragment: "LXD_CHANNEL=5.0/stable", want: true},
+		{name: "holds snap updates", fragment: "snap refresh --hold lxd", want: true},
+		{name: "does not probe PATH for lxd", fragment: "bash -lc 'command -v lxd", want: false},
+		{name: "does not pin a snap revision", fragment: "--revision=", want: false},
+		{name: "does not pin an exact snapd version", fragment: "snapd=", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			g.Expect(strings.Contains(script, tt.fragment)).To(Equal(tt.want))
+		})
+	}
+}

--- a/controllers/templates/lxd_initializer_ds.yaml
+++ b/controllers/templates/lxd_initializer_ds.yaml
@@ -27,7 +27,7 @@ spec:
         effect: "NoSchedule"
       initContainers:
       - name: ensure-lxd
-        # Pinned Ubuntu version: 22.04.3 (tested and verified)
+        # Init container image only needs bash + nsenter; unrelated to the host OS.
         # Using custom registry to avoid Docker Hub rate limits
         image: us-docker.pkg.dev/palette-images/third-party/ubuntu:22.04
         imagePullPolicy: IfNotPresent
@@ -36,50 +36,33 @@ spec:
         - -c
         - |
           set -ex
-          # Check on the HOST, not in the container
-          if ! nsenter -t 1 -m -p -- bash -lc 'command -v lxd >/dev/null 2>&1'; then
-            echo "LXD not present on host, installing snapd and LXD on host";
-            # Pin snapd version to avoid unexpected updates
-            # Version 2.60+ is required for LXD 5.0 support
-            # Using specific version to ensure consistency across deployments
-            nsenter -t 1 -m -p -- bash -lc 'export DEBIAN_FRONTEND=noninteractive; apt-get update && apt-get install -y snapd=2.60.*'
+          # LXD 5.0 is the series verified against our MAAS servers. Install from the
+          # channel, never a pinned revision: snap revisions are per-architecture, so a
+          # single number is not installable everywhere (PCP-7159 reports the old pin,
+          # 38113, as unavailable on amd64) and it silently rots as the series moves.
+          LXD_CHANNEL=5.0/stable
+          # Probe the snap binary on the HOST, not `command -v lxd`. This is the one check
+          # that has to hold on both supported hosts:
+          #   22.04 - nothing named lxd on PATH, so the old check installed correctly
+          #   24.04 - ships the lxd-installer deb, whose stub at /usr/sbin/lxd made the
+          #           old check succeed with no LXD actually installed
+          # /snap/bin/lxd is what every later command uses, so testing for it is accurate
+          # on both. Uses bash's builtin test so it does not depend on host coreutils.
+          if ! nsenter -t 1 -m -p -- bash -lc 'test -x /snap/bin/lxd'; then
+            echo "Snap LXD not present on host, installing snapd and LXD ${LXD_CHANNEL} on host";
+            # snapd ships with Ubuntu server images, so only install when genuinely
+            # missing - and unpinned, because an exact pin (e.g. 2.60.*) does not exist
+            # on every release.
+            nsenter -t 1 -m -p -- bash -lc 'command -v snap >/dev/null 2>&1 || { export DEBIAN_FRONTEND=noninteractive; apt-get update && apt-get install -y snapd; }'
             # Enable and start snapd on the host
             nsenter -t 1 -m -p -- systemctl enable --now snapd.socket
-            # Install LXD 5.0.5 (hardcoded - revision 38113)
-            echo "Installing LXD 5.0.5 (revision 38113)"
-            nsenter -t 1 -m -p -- snap install lxd --revision=38113 || {
-              echo "ERROR: Failed to install LXD revision 38113 (5.0.5)"
+            nsenter -t 1 -m -p -- snap install lxd --channel="${LXD_CHANNEL}" || {
+              echo "ERROR: Failed to install LXD from channel ${LXD_CHANNEL}"
               exit 1
             }
-            
-            # Verify both LXD and LXC are 5.0.5
-            LXD_VERSION=$(nsenter -t 1 -m -p -- /snap/bin/lxd --version 2>&1 | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-            LXC_CLIENT=$(nsenter -t 1 -m -p -- /snap/bin/lxc version 2>&1 | grep "Client version:" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-            LXC_SERVER=$(nsenter -t 1 -m -p -- /snap/bin/lxc version 2>&1 | grep "Server version:" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-            
-            echo "LXD version: ${LXD_VERSION}, LXC client: ${LXC_CLIENT}, LXC server: ${LXC_SERVER}"
-            
-            if [ "${LXD_VERSION}" != "5.0.5" ] || [ "${LXC_CLIENT}" != "5.0.5" ] || [ "${LXC_SERVER}" != "5.0.5" ]; then
-              echo "ERROR: Version mismatch! Expected 5.0.5, got LXD:${LXD_VERSION} LXC-client:${LXC_CLIENT} LXC-server:${LXC_SERVER}"
-              exit 1
-            fi
-            
-            # Hold snap to prevent updates
-            nsenter -t 1 -m -p -- snap refresh --hold lxd
-          else
-            # Verify existing installation is 5.0.5
-            LXD_VERSION=$(nsenter -t 1 -m -p -- /snap/bin/lxd --version 2>&1 | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-            LXC_CLIENT=$(nsenter -t 1 -m -p -- /snap/bin/lxc version 2>&1 | grep "Client version:" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-            LXC_SERVER=$(nsenter -t 1 -m -p -- /snap/bin/lxc version 2>&1 | grep "Server version:" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-            echo "LXD version: ${LXD_VERSION}, LXC client: ${LXC_CLIENT}, LXC server: ${LXC_SERVER}"
-            
-            if [ "${LXD_VERSION}" != "5.0.5" ] || [ "${LXC_CLIENT}" != "5.0.5" ] || [ "${LXC_SERVER}" != "5.0.5" ]; then
-              echo "WARNING: Existing installation is not 5.0.5"
-            fi
-            
-            # Ensure snap is held
-            nsenter -t 1 -m -p -- snap refresh --hold lxd || true
           fi
+          # Hold snap to prevent updates off the verified series
+          nsenter -t 1 -m -p -- snap refresh --hold lxd || true
           echo "Ensuring LXD daemon is running on host";
           # Start/enable via snap (avoid systemd invocation from the pod)
           nsenter -t 1 -m -p -- snap start --enable lxd.daemon || true
@@ -88,9 +71,21 @@ spec:
           if ! nsenter -t 1 -m -p -- /snap/bin/lxd waitready --timeout 300 ; then
             echo "LXD did not become ready after 5 minutes"; exit 1;
           fi
-          # Final version verification
-          FINAL_VERSION=$(nsenter -t 1 -m -p -- /snap/bin/lxd --version 2>&1 || echo "unknown")
-          echo "Host LXD is ready, version: ${FINAL_VERSION}";
+          # Verify the series only after waitready - `lxc version` cannot report a
+          # server version until the daemon is up.
+          LXD_VERSION=$(nsenter -t 1 -m -p -- /snap/bin/lxd --version 2>&1 | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+          LXC_CLIENT=$(nsenter -t 1 -m -p -- /snap/bin/lxc version 2>&1 | grep "Client version:" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+          LXC_SERVER=$(nsenter -t 1 -m -p -- /snap/bin/lxc version 2>&1 | grep "Server version:" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+          echo "Host LXD is ready - LXD version: ${LXD_VERSION}, LXC client: ${LXC_CLIENT}, LXC server: ${LXC_SERVER}";
+          # Warn, don't exit - waitready already proved LXD works, and a host that came
+          # up on another 5.x should not start crashlooping. A real incompatibility
+          # surfaces in the lxd-initializer container at MAAS registration.
+          for v in "${LXD_VERSION}" "${LXC_CLIENT}" "${LXC_SERVER}"; do
+            case "${v}" in
+              5.0.*) ;;
+              *) echo "WARNING: expected LXD 5.0.x, got LXD:${LXD_VERSION} LXC-client:${LXC_CLIENT} LXC-server:${LXC_SERVER}"; break ;;
+            esac
+          done
         securityContext:
           privileged: true
         volumeMounts:

--- a/lxd-initializer/lxd-initializer.go
+++ b/lxd-initializer/lxd-initializer.go
@@ -527,16 +527,22 @@ func main() {
 		actionStr = "both" // Default to both init and register
 	}
 
-	// Early exit: if node already marked initialized, skip all work
+	// Early exit: if node already marked initialized, skip all work. The label can go
+	// stale (host reimaged, LXD snap removed), so it is only trusted when LXD is
+	// actually functional - otherwise the node would never re-register with MAAS.
 	if nodeName != "" {
 		if client, err := getKubernetesClient(); err == nil {
 			if node, gerr := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{}); gerr == nil {
 				if node.Labels != nil {
 					if node.Labels[LXDHostInitializedLabel] == LabelValueTrue {
-						log.Printf("Node %s already labeled %s=true; skipping initializer", nodeName, LXDHostInitializedLabel)
-						log.Printf("Sleeping for 1 hour to keep the container running")
-						time.Sleep(3600 * time.Second)
-						return
+						if verr := validateLXDFunctional(); verr != nil {
+							log.Printf("Node %s labeled %s=true but LXD is not functional (%v); re-running initializer", nodeName, LXDHostInitializedLabel, verr)
+						} else {
+							log.Printf("Node %s already labeled %s=true; skipping initializer", nodeName, LXDHostInitializedLabel)
+							log.Printf("Sleeping for 1 hour to keep the container running")
+							time.Sleep(3600 * time.Second)
+							return
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- Backport of [#377](https://github.com/spectrocloud-public/cluster-api-provider-maas/pull/377) (PCP-7159) onto `spectro-release-4.9`.
- Fixes `ensure-lxd` crashloop on Ubuntu 24.04 (`lxd-installer` stub fooled `command -v lxd`) and replaces the rotting `--revision=38113` pin with `5.0/stable`.
- Omits the incidental `go.mod`/`go.sum` bumps from the original merge; LXD-only change set.

## Why 4.9.7 still shows 5.0.3
`v0.6.1-spectro-4.9.7` only has PCP-7384. On existing hosts the old initializer holds whatever is already installed (e.g. 5.0.3) and only warns — it does not refresh. Fresh installs were pinned to 5.0.5/`38113`, which is also unavailable on some arches.

## Test plan
- [x] `go test ./controllers/ -run TestEnsureLXDScript -vet=off`
- [ ] Lab: new HCP node on Ubuntu 24.04 reaches Ready / LXD registered
- [ ] Lab: Ubuntu 22.04 regression (cluster create still works)
- [ ] Confirm new hosts land on current `5.0/stable` (not stuck on 5.0.3/5.0.5 pin)


Made with [Cursor](https://cursor.com)